### PR TITLE
Update the property to fix the migration issue

### DIFF
--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -14,7 +14,7 @@ spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.Im
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.hibernate.naming_strategy=org.hibernate.cfg.EJB3NamingStrategy
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 
 spring.datasource.dbiemr.url=jdbc:mysql://localhost:3306/db_iemr
 spring.datasource.dbiemr.username=root

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,7 +13,7 @@ spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.Im
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.hibernate.naming_strategy=org.hibernate.cfg.EJB3NamingStrategy
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=update
 
 spring.flyway.locations=classpath:db/migration
 spring.flyway.validateMigrationNaming=true


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

Update the property "**spring.jpa.hibernate.ddl-auto**" from **none** to **update** to automatically update the database schema to match the entities.

---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application’s configuration to enable automatic updates to the database schema, ensuring that data structures remain synchronized with the application’s definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->