### PR TITLE
Bug Fix:  Application startup issue due to missing entityManagerFactory Bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,6 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
  		<dependency>
@@ -43,11 +39,6 @@
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
 			<version>8.2.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hibernate.javax.persistence</groupId>
-			<artifactId>hibernate-jpa-2.0-api</artifactId>
-			<version>1.0.1.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -94,6 +85,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-jdbc</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/environment/common_example.properties
+++ b/src/main/environment/common_example.properties
@@ -10,11 +10,6 @@ spring.datasource.tomcat.remove-abandoned=true
 spring.datasource.tomcat.logAbandoned=true
 spring.datasource.continue-on-error=true
 spring.datasource.tomcat.remove-abandoned-timeout=600
-spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.jpa.hibernate.naming_strategy=org.hibernate.cfg.EJB3NamingStrategy
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=update
 
 spring.datasource.dbiemr.url=jdbc:mysql://localhost:3306/db_iemr
 spring.datasource.dbiemr.username=root

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,11 +9,7 @@ spring.datasource.tomcat.remove-abandoned=true
 spring.datasource.tomcat.logAbandoned=true
 spring.datasource.continue-on-error=true
 spring.datasource.tomcat.remove-abandoned-timeout=600
-spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.jpa.hibernate.naming_strategy=org.hibernate.cfg.EJB3NamingStrategy
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
-spring.jpa.hibernate.ddl-auto=update
+
 
 spring.flyway.locations=classpath:db/migration
 spring.flyway.validateMigrationNaming=true


### PR DESCRIPTION


## ✅ Type of Change
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)


## ℹ️ Additional Information

The issue was due to a bean named entityManagerFactory not being available, causing a NoSuchBeanDefinitionException during application startup with mvn spring-boot:run -DENV_VAR=local. This stemmed from an unintended JPA configuration in the project, which conflicted with the app's focus on Flyway-based schema management and JdbcTemplate queries.

Changes Made:

Removed unnecessary JPA dependencies from pom.xml:
spring-boot-starter-data-jpa (included Hibernate and Spring Data JPA).
hibernate-jpa-2.0-api (redundant JPA API).
Added spring-boot-starter-jdbc to support DataSource and JdbcTemplate functionality, aligning with the app's use of JdbcTemplateConfig.java for version queries and DatasourceConfig.java for multiple database connections.
Removed JPA-related properties from common_local.properties:
spring.jpa.hibernate.naming.implicit-strategy
spring.jpa.hibernate.naming.physical-strategy
spring.jpa.hibernate.naming_strategy
spring.jpa.properties.hibernate.dialect
spring.jpa.hibernate.ddl-auto
These properties were irrelevant since the app relies on Flyway for schema management (per the README) and has no @Entity or @Repository classes.

Impact:
Resolves the NoSuchBeanDefinitionException, enabling successful application startup.
Maintains core functionality: Flyway migrations for db_iemr, db_reporting, db_identity, and db_1097_identity, and the /db/migration/version endpoint.
Verified with mvn clean install -DENV_VAR=local and mvn spring-boot:run -DENV_VAR=local.

Testing:

Confirmed application startup without errors.
Tested http://localhost:8080/db/migration/version (please verify this endpoint works as expected and share results if issues arise).

## ℹ️Result Screenshots

Below are the attached screenshots of the occurence of error before, and the results of hitting the api after resolving the issue
On running the following maven command:

![Screenshot 2025-04-19 173409](https://github.com/user-attachments/assets/6c58d4b7-3260-4ebf-a286-b9c20f5d5ca5)

The issue that occured before:

![Screenshot 2025-04-19 174026](https://github.com/user-attachments/assets/615f2046-c861-4182-960c-a6d345b25f19)

The successful hitting of the API endpoint http://localhost:8080/db/migration/version after resolving the issue to start the application successfully:

![Screenshot 2025-04-19 175821](https://github.com/user-attachments/assets/7a394882-54f8-477b-b64b-0ebe54f0399f)

