### PR TITLE
fix: reset dummy user passwords to 'password' via migration

### DIFF
--- a/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
+++ b/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
@@ -1,0 +1,5 @@
+-- Update passwords for dummy users to 'password'
+
+UPDATE m_user 
+SET Password = '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.TVuHOnu' 
+WHERE UserName IN ('SuperAdmin', 'GOKAHWC', 'Hwc', 'Nurse');

--- a/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
+++ b/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
@@ -4,3 +4,4 @@ UPDATE m_user
 SET Password = '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.TVuHOnu' 
 WHERE UserName IN ('SuperAdmin', 'GOKAHWC', 'Hwc', 'Nurse');
 
+

--- a/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
+++ b/src/main/resources/db/migration/dbiemr/V100__fix_dummy_login_credentials.sql
@@ -3,3 +3,4 @@
 UPDATE m_user 
 SET Password = '$2a$10$8.UnVuG9HHgffUDAlk8qfOuVGkqRzgVymGe07xd00DMxs.TVuHOnu' 
 WHERE UserName IN ('SuperAdmin', 'GOKAHWC', 'Hwc', 'Nurse');
+


### PR DESCRIPTION
## 📋 Description
JIRA ID: Fixes PSMRI/AMRIT#23

Summary:
Added a new database migration script (V100__fix_dummy_login_credentials.sql) to reset the passwords for default dummy accounts.

Motivation:
Currently, dummy accounts (SuperAdmin, GOKAHWC, Hwc, and Nurse) in the local development environment have unknown encrypted passwords. This creates a blocker for new contributors who are unable to log in and test the Common-API or TM-API services. This change provides a "fix-forward" approach by overwriting those passwords with a known BCrypt hash for the word "password".

---

## ✅ Type of Change

[x] Bug fix (non-breaking change which resolves an issue)

[x] Config change (database migration update)

---
Testing & Verification:

Flyway Verification: Confirmed the file is placed in src/main/resources/db/migration/dbiemr/ to be automatically picked up by the Flyway migration tool.

Security Compatibility: Implemented a standard BCrypt salted hash. This ensures compatibility with the existing Spring Security configuration in the Common-API.

Local Credentials: Verified that these accounts are now usable for local testing with the password: password.

Context:
This fix unblocks the local development setup for all services relying on the db_iemr schema, ensuring technical maturity for systems engineering tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reset and standardized credentials for dummy/test user accounts to ensure they work consistently across environments and tests. This update affects only non-production test accounts and improves reliability of development and QA workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->