### PR TITLE
perf: V84 composite indexes for ECD outbound call allocation (504 fix)

### DIFF
--- a/src/main/resources/db/migration/dbiemr/V83__ECD_outbound_calls_performance_indexes.sql
+++ b/src/main/resources/db/migration/dbiemr/V83__ECD_outbound_calls_performance_indexes.sql
@@ -1,0 +1,107 @@
+USE db_iemr;
+
+/* =========================================================
+   ECD Outbound Call Allocation — Performance Indexes
+   Fixes 504 Gateway Timeout on /callAllocation/getEligibleRecordsInfo
+   for Child + Self phone type on large production datasets.
+
+   Root cause: 3 sequential COUNT queries each did a full scan of
+   t_mctsoutboundcalls (4M+ rows). Existing single-column indexes on
+   phoneNumberType (cardinality=2) and ProviderServiceMapID (cardinality=2)
+   were skipped by the MySQL optimizer as non-selective.
+
+   Fix: composite indexes that let the optimizer seek directly to the
+   matching subset instead of scanning the full table.
+   ========================================================= */
+
+-- =========================================================
+-- t_mctsoutboundcalls — Child lookup
+-- Covers: ProviderServiceMapID + ChildID + phoneNumberType + CallDateTo + CallDateFrom
+-- Used by: getChildUnAllocatedCountLR, getChildUnAllocatedCountHR, getTotalAllocatedCountChild
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_mctsoutboundcalls'
+    AND index_name = 'idx_outbound_child_lookup'
+);
+
+SET @sql = IF(
+    @idx_exists = 0,
+    'CREATE INDEX idx_outbound_child_lookup ON t_mctsoutboundcalls (ProviderServiceMapID, ChildID, phoneNumberType, CallDateTo, CallDateFrom) ALGORITHM=INPLACE LOCK=NONE',
+    'SELECT ''idx_outbound_child_lookup already exists'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================================================
+-- t_mctsoutboundcalls — Mother lookup
+-- Covers: ProviderServiceMapID + ChildID + MotherID + phoneNumberType + CallDateTo + CallDateFrom
+-- Used by: getMotherUnAllocatedCountLR, getMotherUnAllocatedCountHR, getTotalAllocatedCountMother
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_mctsoutboundcalls'
+    AND index_name = 'idx_outbound_mother_lookup'
+);
+
+SET @sql = IF(
+    @idx_exists = 0,
+    'CREATE INDEX idx_outbound_mother_lookup ON t_mctsoutboundcalls (ProviderServiceMapID, ChildID, MotherID, phoneNumberType, CallDateTo, CallDateFrom) ALGORITHM=INPLACE LOCK=NONE',
+    'SELECT ''idx_outbound_mother_lookup already exists'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================================================
+-- t_childvaliddata — Child record count lookup
+-- Covers: IsAllocated + Phone_No_of + CreatedDate
+-- Used by: childRecordRepo.getRecordCount (introductory count)
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_childvaliddata'
+    AND index_name = 'idx_childvalid_count_lookup'
+);
+
+SET @sql = IF(
+    @idx_exists = 0,
+    'CREATE INDEX idx_childvalid_count_lookup ON t_childvaliddata (IsAllocated, Phone_No_of, CreatedDate) ALGORITHM=INPLACE LOCK=NONE',
+    'SELECT ''idx_childvalid_count_lookup already exists'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================================================
+-- t_mothervalidrecord — Mother record count lookup
+-- Covers: IsAllocated + PhoneNo_Of_Whom + CreatedDate
+-- Used by: motherRecordRepo.getRecordCount (introductory count)
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_mothervalidrecord'
+    AND index_name = 'idx_mothervalid_count_lookup'
+);
+
+SET @sql = IF(
+    @idx_exists = 0,
+    'CREATE INDEX idx_mothervalid_count_lookup ON t_mothervalidrecord (IsAllocated, PhoneNo_Of_Whom, CreatedDate) ALGORITHM=INPLACE LOCK=NONE',
+    'SELECT ''idx_mothervalid_count_lookup already exists'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/dbiemr/V84__ECD_restructure_idx_mcts_eligible_v2.sql
+++ b/src/main/resources/db/migration/dbiemr/V84__ECD_restructure_idx_mcts_eligible_v2.sql
@@ -1,0 +1,61 @@
+USE db_iemr;
+
+/* =========================================================
+   ECD Outbound Call Allocation — Restructure idx_mcts_eligible_v2
+   Related fix: 504 Gateway Timeout on /callAllocation/getEligibleRecordsInfo
+
+   Root cause of bad index performance:
+   Original column order started with ChildID (IS NOT NULL = range condition),
+   causing MySQL to stop at column 1 and scan 2M+ rows. Columns
+   ProviderServiceMapID and phoneNumberType were never reached by the optimizer.
+
+   Fix: reorder columns so equality filters come first, range columns last.
+   New order: ProviderServiceMapID → phoneNumberType → AllocationStatus → ChildID → CallDateTo
+   This lets MySQL seek to the exact PSM+phoneType+allocationStatus subset
+   (~19K rows) before applying the ChildID range filter.
+   ========================================================= */
+
+-- =========================================================
+-- Step 1: Drop existing idx_mcts_eligible_v2 if it exists
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_mctsoutboundcalls'
+    AND index_name = 'idx_mcts_eligible_v2'
+);
+
+SET @sql = IF(
+    @idx_exists > 0,
+    'ALTER TABLE t_mctsoutboundcalls DROP INDEX idx_mcts_eligible_v2',
+    'SELECT ''idx_mcts_eligible_v2 does not exist, skipping drop'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- =========================================================
+-- Step 2: Recreate idx_mcts_eligible_v2 with optimal column order
+-- Covers: ProviderServiceMapID (equality) → phoneNumberType (equality) →
+--         AllocationStatus (equality) → ChildID (IS NOT NULL range) → CallDateTo (range)
+-- Used by: getChildUnAllocatedCountLR, getChildUnAllocatedCountHR, getTotalAllocatedCountChild
+-- =========================================================
+
+SET @idx_exists = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = 'db_iemr'
+    AND table_name = 't_mctsoutboundcalls'
+    AND index_name = 'idx_mcts_eligible_v2'
+);
+
+SET @sql = IF(
+    @idx_exists = 0,
+    'ALTER TABLE t_mctsoutboundcalls ADD INDEX idx_mcts_eligible_v2 (ProviderServiceMapID, phoneNumberType, AllocationStatus, ChildID, CallDateTo) ALGORITHM=INPLACE LOCK=NONE',
+    'SELECT ''idx_mcts_eligible_v2 already exists'''
+);
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
Adds 4 composite indexes to resolve 504 Gateway Timeout on /callAllocation/getEligibleRecordsInfo for Child + Self phone type on large production datasets (4M+ rows in t_mctsoutboundcalls).

Existing single-column indexes on phoneNumberType and ProviderServiceMapID were ignored by MySQL optimizer due to low cardinality (~2). Composite indexes let the optimizer seek directly to the matching subset.

Indexes:
- idx_outbound_child_lookup on t_mctsoutboundcalls
- idx_outbound_mother_lookup on t_mctsoutboundcalls
- idx_childvalid_count_lookup on t_childvaliddata
- idx_mothervalid_count_lookup on t_mothervalidrecord

## 📋 Description

JIRA ID: 

AMM-2353
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

Please describe how the changes were tested, and include any relevant screenshots, logs, or other information that provides additional context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database optimization: Added and reorganized MySQL performance indexes to speed up outbound call allocation lookups and validation count queries, improving responsiveness under high-volume workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->