### PR TITLE
Make V83 view drop idempotent (DROP VIEW IF EXISTS)

### DIFF
--- a/src/main/resources/db/migration/dbiemr/V83__DB_view_correction.sql
+++ b/src/main/resources/db/migration/dbiemr/V83__DB_view_correction.sql
@@ -1,4 +1,4 @@
-drop view v_fetchfacility;
+DROP VIEW IF EXISTS v_fetchfacility;
 
 CREATE 
     ALGORITHM = UNDEFINED 


### PR DESCRIPTION
## Problem

`V83__DB_view_correction.sql` begins with a bare:

```sql
drop view v_fetchfacility;
```

On a fresh Flyway build this works because `v_fetchfacility` is created earlier in `V1__DB_IEMR.sql`. But when a database is **seeded from a SQL dump** that predates the view (or otherwise doesn't contain it) and Flyway then applies the remaining migrations, V83 fails at startup with:

```
java.sql.SQLSyntaxErrorException: Unknown table 'db_iemr.v_fetchfacility'
```

Because AMRIT-DB runs the Flyway migration in a `@PostConstruct`, this aborts application startup (the service then crash-loops under systemd).

## Fix

Change the bare drop to `DROP VIEW IF EXISTS v_fetchfacility;`. The subsequent `CREATE VIEW` is unchanged, so the resulting view definition is identical — this only makes the drop tolerant of the view being absent.

This is the **only** bare `DROP VIEW` in the `dbiemr` migrations; the other 64 view drops already use `DROP VIEW IF EXISTS`, so this simply aligns V83 with the existing convention.

## Safety on already-migrated environments

Editing an applied migration changes its Flyway checksum. AMRIT-DB's `FlywayMigrator` calls `repair()` before `migrate()`, which realigns `flyway_schema_history` checksums, so existing environments where V83 already ran are reconciled automatically — no manual repair needed.

## How it was found

Reproduced on a fresh Ubuntu + MySQL 8 provisioning of a camp laptop: importing a full production dump, then starting `amrit-db` to apply pending migrations, failed at V83. With this change the migration completes cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a database view update so it applies reliably during deployments, helping prevent issues when loading facility-related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->