### PR TITLE
Remove hardcoded DEFINER clauses so migrations run as any DB user

### DIFF
--- a/src/main/resources/db/migration/db1097identity/V1__DB_1097_IDENTITY.sql
+++ b/src/main/resources/db/migration/db1097identity/V1__DB_1097_IDENTITY.sql
@@ -1191,7 +1191,7 @@ CREATE TABLE IF NOT EXISTS `t_bendataaccess` (
 -- /*!50001 SET character_set_results     = utf8 */;
 -- /*!50001 SET collation_connection      = utf8_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `v_benadvancesearch` AS select `benmap`.`BenMapId` AS `BenMapId`,`benmap`.`BenRegId` AS `BenRegId`,`benmap`.`BenDetailsId` AS `BenDetailsId`,`benmap`.`BenAddressId` AS `BenAddressId`,`benmap`.`BenImageId` AS `BenImageId`,`benmap`.`BenContactsId` AS `BenContactsId`,`benmap`.`BenConsentId` AS `BenConsentId`,`benmap`.`BenAccountID` AS `BenAccountID`,`benmap`.`BenSecureStackId` AS `BenSecureStackId`,`benmap`.`VanSerialNo` AS `VanSerialNo`,`benmap`.`VanID` AS `VanID`,`benadd`.`CurrStateId` AS `CurrStateId`,`benadd`.`CurrDistrictId` AS `CurrDistrictId`,`bendetail`.`FirstName` AS `FirstName`,`bendetail`.`MiddleName` AS `MiddleName`,`bendetail`.`LastName` AS `LastName`,`bendetail`.`GenderId` AS `GenderId` from ((`i_beneficiarymapping` `benmap` join `i_beneficiarydetails` `bendetail` on(((`benmap`.`BenDetailsId` = `bendetail`.`VanSerialNo`) and (`benmap`.`VanID` = `bendetail`.`VanID`)))) join `i_beneficiaryaddress` `benadd` on(((`benmap`.`BenAddressId` = `benadd`.`VanSerialNo`) and (`benmap`.`VanID` = `benadd`.`VanID`)))) */;
 -- /*!50001 SET character_set_client      = @saved_cs_client */;
 -- /*!50001 SET character_set_results     = @saved_cs_results */;
@@ -1209,7 +1209,7 @@ CREATE TABLE IF NOT EXISTS `t_bendataaccess` (
 -- /*!50001 SET character_set_results     = utf8 */;
 -- /*!50001 SET collation_connection      = utf8_general_ci */;
 /*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
+/*!50013 SQL SECURITY DEFINER */
 /*!50001 VIEW `v_centraldashboard` AS select `bsm`.`BenServiceMapID` AS `BenServiceMapID`,`bsm`.`BenMapID` AS `BenMapID`,`bsm`.`ProviderServiceMapId` AS `ProviderServiceMapId`,`bsm`.`VanID` AS `VanID`,`psm`.`ServiceID` AS `ServiceID`,`psm`.`ServiceProviderID` AS `ServiceProviderID`,`psm`.`StateID` AS `StateID`,`bm`.`BenDetailsId` AS `BenDetailsId`,`bd`.`GenderId` AS `GenderId`,`bd`.`Gender` AS `Gender`,`bd`.`DOB` AS `DOB`,floor(((to_days(`bd`.`CreatedDate`) - to_days(`bd`.`DOB`)) / 365.25)) AS `age` from (((`db_1097_identity`.`i_beneficiaryservicemapping` `bsm` join `db_iemr`.`m_providerservicemapping` `psm` on((`bsm`.`ProviderServiceMapId` = `psm`.`ProviderServiceMapID`))) join `db_1097_identity`.`i_beneficiarymapping` `bm` on((`bsm`.`BenMapID` = `bm`.`BenMapId`))) join `db_1097_identity`.`i_beneficiarydetails` `bd` on((`bm`.`BenDetailsId` = `bd`.`BeneficiaryDetailsId`))) */;
 -- /*!50001 SET character_set_client      = @saved_cs_client */;
 -- /*!50001 SET character_set_results     = @saved_cs_results */;

--- a/src/main/resources/db/migration/dbiemr/V13__QUALITY_MODULE_CATEGORY_MAPPING.sql
+++ b/src/main/resources/db/migration/dbiemr/V13__QUALITY_MODULE_CATEGORY_MAPPING.sql
@@ -32,7 +32,6 @@ DROP VIEW IF EXISTS db_iemr.v_get_qualityaudit_sectionquestionairevalues;
 
 CREATE 
     ALGORITHM = UNDEFINED 
-    DEFINER = `piramaldev`@`%` 
     SQL SECURITY DEFINER
 VIEW `db_iemr`.`v_get_qualityaudit_sectionquestionairevalues` AS
     SELECT 

--- a/src/main/resources/db/migration/dbiemr/V32__Assam_SP.sql
+++ b/src/main/resources/db/migration/dbiemr/V32__Assam_SP.sql
@@ -4,7 +4,7 @@ DROP PROCEDURE IF EXISTS Pr_GetCallHistory;
 
 DELIMITER $$
 
-CREATE DEFINER=`piramaldev`@`%` PROCEDURE `Pr_GetCallHistory`(
+CREATE PROCEDURE `Pr_GetCallHistory`(
     IN v_obcallid INT
 )
 BEGIN

--- a/src/main/resources/db/migration/dbiemr/V34__SP_ECD.sql
+++ b/src/main/resources/db/migration/dbiemr/V34__SP_ECD.sql
@@ -3,7 +3,7 @@ Drop procedure if exists PR_FetchECDMotherOutboundWorklist;
 
 DELIMITER $$
 
-CREATE DEFINER=`piramaldev`@`%` PROCEDURE `PR_FetchECDMotherOutboundWorklist`(v_AllocatedUserID int)
+CREATE PROCEDURE `PR_FetchECDMotherOutboundWorklist`(v_AllocatedUserID int)
 BEGIN
  declare v_NextAttemptPeriod int(11);
 select distinct NextAttemptPeriod into v_NextAttemptPeriod from m_mctscallconfiguration

--- a/src/main/resources/db/migration/dbiemr/V35__ECD_Child_SP.sql
+++ b/src/main/resources/db/migration/dbiemr/V35__ECD_Child_SP.sql
@@ -3,7 +3,7 @@ Drop procedure if exists PR_FetchECDChildOutboundWorklist;
 
 
 DELIMITER ;;
-CREATE DEFINER=`piramaldev`@`%` PROCEDURE `PR_FetchECDChildOutboundWorklist`(v_AllocatedUserID int)
+CREATE PROCEDURE `PR_FetchECDChildOutboundWorklist`(v_AllocatedUserID int)
 BEGIN
 
 declare v_NextAttemptPeriod int(11);

--- a/src/main/resources/db/migration/dbiemr/V62__DB_v_drugforprescription.sql
+++ b/src/main/resources/db/migration/dbiemr/V62__DB_v_drugforprescription.sql
@@ -4,7 +4,6 @@ Drop VIEW if Exists v_drugforprescription;
 
 CREATE 
     ALGORITHM = UNDEFINED 
-    DEFINER = `root`@`localhost` 
     SQL SECURITY DEFINER
 VIEW `db_iemr`.`v_drugforprescription` AS
     SELECT 

--- a/src/main/resources/db/migration/dbiemr/V71__ECD_Mother_HighRisk_Reason_SP.sql
+++ b/src/main/resources/db/migration/dbiemr/V71__ECD_Mother_HighRisk_Reason_SP.sql
@@ -3,7 +3,7 @@ Drop procedure if exists PR_FetchECDMotherOutboundWorklist;
 
 DELIMITER $$
 
-CREATE DEFINER=`piramaldev`@`%` PROCEDURE `PR_FetchECDMotherOutboundWorklist`(v_AllocatedUserID int)
+CREATE PROCEDURE `PR_FetchECDMotherOutboundWorklist`(v_AllocatedUserID int)
 BEGIN
  declare v_NextAttemptPeriod int(11);
 select distinct NextAttemptPeriod into v_NextAttemptPeriod from m_mctscallconfiguration

--- a/src/main/resources/db/migration/dbiemr/V83__DB_view_correction.sql
+++ b/src/main/resources/db/migration/dbiemr/V83__DB_view_correction.sql
@@ -2,7 +2,6 @@ DROP VIEW IF EXISTS v_fetchfacility;
 
 CREATE 
     ALGORITHM = UNDEFINED 
-    DEFINER = `piramaldev`@`%` 
     SQL SECURITY DEFINER
 VIEW `v_fetchfacility` AS
     SELECT 


### PR DESCRIPTION
Nine `DEFINER` clauses across eight migrations pin the object owner to a specific account. This makes a fresh deployment fail unless the database user happens to be named `piramaldev`, and `dbiemr/V62` cannot be applied by any non-root account at all.

| migration(s) | clause |
|---|---|
| `dbiemr` V13, V32, V34, V35, V71, V83 | ``DEFINER=`piramaldev`@`%` `` |
| `dbiemr` V62 | ``DEFINER=`root`@`localhost` `` |
| `db1097identity` V1 (×2) | ``DEFINER=`root`@`localhost` `` |

## Why it breaks

MySQL only lets an account create an object whose `DEFINER` equals that account, unless it holds `SET_USER_ID`. Since 8.0.16 `root@localhost` is additionally a *system account*, so attributing an object to it also requires `SYSTEM_USER` — which is close to root-equivalent and not something an application account should hold.

Because `FlywayMigrator` runs in `@PostConstruct`, the failure presents as `amrit-db` crash-looping rather than as a clean migration error, which makes it expensive to diagnose.

## Measured on MySQL 8.0.46, as an ordinary unprivileged app user

| form | result |
|---|---|
| ``DEFINER=`root`@`localhost` `` | `ERROR 1227` — needs `SYSTEM_USER` |
| ``DEFINER=`otherpartner`@`%` `` | `ERROR 1227` — needs `SET_USER_ID` |
| ``DEFINER=`piramaldev`@`%` `` | OK, but only because that *is* the connecting account |
| **no `DEFINER` clause (this PR)** | **OK with zero elevated privileges** |

## The change

Removing the clause makes MySQL default the definer to `CURRENT_USER` — whichever account runs the migration. Verified: the resulting objects record `definer = <migrating user>`.

`SQL SECURITY DEFINER` is preserved everywhere it appeared, so the privilege semantics of each view and routine are unchanged. Only the identity it binds to changes, from a hardcoded name to the actual owner.

Diff is 6 insertions / 9 deletions. Three shapes were handled separately to keep each edit minimal:
- multi-line view headers (`CREATE` / `ALGORITHM` / `DEFINER` / `SQL SECURITY DEFINER`)
- inline ``CREATE DEFINER=`u`@`h` PROCEDURE``
- mysqldump `/*!50013 ... */` version-gated comments

## Why this is safe for existing deployments

`FlywayMigrator.migrate()` calls `.repair()` on all four Flyway instances before `.migrate()`, which realigns checksums in `flyway_schema_history` on every startup — so editing an applied migration does not cause a checksum mismatch. And on existing deployments these migrations have already been applied, so they will not re-run at all.

## Secondary benefit

A hardcoded `DEFINER` is also a latent *runtime* fault: an object whose definer does not exist on the target server fails when queried with `The user specified as a definer does not exist`. That surfaces as a broken screen rather than a failed deployment, long after the fact.

## How this was found

Standing up AMRIT MMU for a new partner on a clean Ubuntu 24.04 / MySQL 8.0 host with a per-partner database user. Without this change the deployment needs the DB user renamed to `piramaldev` *and* a temporary `SYSTEM_USER` grant during migration; with it, neither is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database views and stored procedures to avoid relying on hard-coded execution-owner accounts.
  * Preserved existing view results, procedure parameters, and business logic.
  * Improved migration compatibility across environments with different database account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->