### PR TITLE
fix: v_getagentsbyroleid returns duplicate agent rows per language mapping

### DIFF
--- a/src/main/resources/db/migration/dbiemr/V91__fix_v_getagentsbyroleid_duplicates.sql
+++ b/src/main/resources/db/migration/dbiemr/V91__fix_v_getagentsbyroleid_duplicates.sql
@@ -1,0 +1,41 @@
+-- v_getagentsbyroleid (defined in V2__DB_IEMR.sql) LEFT JOINs m_userlangmapping directly
+-- on UserID. m_userlangmapping is one-to-many per user (one row per language the agent
+-- speaks/reads), so the join fans out and duplicates every agent row once per language
+-- mapping -- e.g. an agent with 4 language rows shows up 4 times in getAgentsByRoleId.
+-- Replacing the join with correlated subqueries for the CanRead=1 language keeps exactly
+-- one row per usr.USRMappingID.
+
+DROP VIEW IF EXISTS v_getagentsbyroleid;
+
+CREATE
+    ALGORITHM = UNDEFINED
+    DEFINER = `piramaldev`@`%`
+    SQL SECURITY DEFINER
+VIEW `v_getagentsbyroleid` AS
+    SELECT
+        `usr`.`USRMappingID` AS `USRMappingID`,
+        `u`.`UserID` AS `UserID`,
+        `u`.`FirstName` AS `FirstName`,
+        `u`.`MiddleName` AS `MiddleName`,
+        `u`.`LastName` AS `LastName`,
+        `usr`.`RoleID` AS `RoleID`,
+        `usr`.`AgentID` AS `AgentID`,
+        (SELECT `ulm`.`LanguageID`
+            FROM `m_userlangmapping` `ulm`
+            WHERE `ulm`.`UserID` = `usr`.`UserID`
+                AND ((0 <> `ulm`.`CanRead`) IS TRUE)
+            ORDER BY `ulm`.`LanguageID`
+            LIMIT 1) AS `preferredlanguageid`,
+        (SELECT `l`.`LanguageName`
+            FROM `m_userlangmapping` `ulm`
+            JOIN `m_language` `l` ON (`l`.`LanguageID` = `ulm`.`LanguageID`)
+            WHERE `ulm`.`UserID` = `usr`.`UserID`
+                AND ((0 <> `ulm`.`CanRead`) IS TRUE)
+            ORDER BY `ulm`.`LanguageID`
+            LIMIT 1) AS `preferredlanguage`
+    FROM
+        `m_user` `u`
+        JOIN `m_userservicerolemapping` `usr` ON (`u`.`UserID` = `usr`.`UserID`)
+    WHERE
+        ((0 <> `u`.`Deleted`) IS FALSE)
+        AND ((0 <> `usr`.`Deleted`) IS FALSE);


### PR DESCRIPTION
## Summary
- `v_getagentsbyroleid` (defined in V2__DB_IEMR.sql) LEFT JOINs `m_userlangmapping` directly on `UserID`. That table is one-to-many per user (one row per language the agent can read/speak), so the join fans out and duplicates every agent row once per readable language mapping.
- Replaces the join with correlated subqueries (for the `CanRead=1` language) to guarantee exactly one row per `usr.USRMappingID`.

## Test plan
- [ ] Apply migration against an environment with agents that have multiple `CanRead=1` rows in `m_userlangmapping`
- [ ] Confirm `SELECT * FROM v_getagentsbyroleid` returns one row per `USRMappingID` (no duplicates)
- [ ] Confirm `preferredlanguageid`/`preferredlanguage` are still populated correctly for agents with a single readable language

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate agent entries when retrieving agents by role.
  * Preferred language information is now selected consistently, ensuring each agent appears only once in the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->