### PR TITLE
Add migrations for beneficiary residence columns and diagnostic devic…

### DIFF
--- a/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
+++ b/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
@@ -1,0 +1,101 @@
+-- ==========================================================
+-- Add place of current living related columns to beneficiary
+-- tables.
+--
+-- Safe to execute multiple times. Each column is added only
+-- if it does not already exist.
+-- ==========================================================
+
+USE db_identity;
+
+-- ==========================================================
+-- i_beneficiarydetails
+-- ==========================================================
+
+-- placeOfCurrentLiving
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
+        'SELECT "placeOfCurrentLiving already exists in i_beneficiarydetails";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails'
+      AND COLUMN_NAME = 'placeOfCurrentLiving'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- otherPlaceOfCurrentLiving
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
+        'SELECT "otherPlaceOfCurrentLiving already exists in i_beneficiarydetails";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails'
+      AND COLUMN_NAME = 'otherPlaceOfCurrentLiving'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- institutionName
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN institutionName VARCHAR(255) NULL;',
+        'SELECT "institutionName already exists in i_beneficiarydetails";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails'
+      AND COLUMN_NAME = 'institutionName'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================================
+-- i_beneficiarydetails_rmnch
+-- ==========================================================
+
+-- placeOfCurrentLiving
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
+        'SELECT "placeOfCurrentLiving already exists in i_beneficiarydetails_rmnch";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+      AND COLUMN_NAME = 'placeOfCurrentLiving'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- otherPlaceOfCurrentLiving
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
+        'SELECT "otherPlaceOfCurrentLiving already exists in i_beneficiarydetails_rmnch";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+      AND COLUMN_NAME = 'otherPlaceOfCurrentLiving'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- institutionName
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN institutionName VARCHAR(255) NULL;',
+        'SELECT "institutionName already exists in i_beneficiarydetails_rmnch";')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+      AND COLUMN_NAME = 'institutionName'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
+++ b/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
@@ -1,9 +1,10 @@
 -- ==========================================================
 -- Add place of current living related columns to beneficiary
--- tables.
+-- and household tables.
 --
--- Safe to execute multiple times. Each column is added only
--- if it does not already exist.
+-- Safe to execute multiple times.
+-- Each column is added only if it does not already exist.
+-- MODIFY statements execute only if the target column exists.
 -- ==========================================================
 
 USE db_identity;
@@ -16,7 +17,7 @@ USE db_identity;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
-        'SELECT "placeOfCurrentLiving already exists in i_beneficiarydetails";')
+        'SELECT ''placeOfCurrentLiving already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails'
@@ -30,7 +31,7 @@ DEALLOCATE PREPARE stmt;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
-        'SELECT "otherPlaceOfCurrentLiving already exists in i_beneficiarydetails";')
+        'SELECT ''otherPlaceOfCurrentLiving already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails'
@@ -44,7 +45,7 @@ DEALLOCATE PREPARE stmt;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN institutionName VARCHAR(255) NULL;',
-        'SELECT "institutionName already exists in i_beneficiarydetails";')
+        'SELECT ''institutionName already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails'
@@ -62,7 +63,7 @@ DEALLOCATE PREPARE stmt;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
-        'SELECT "placeOfCurrentLiving already exists in i_beneficiarydetails_rmnch";')
+        'SELECT ''placeOfCurrentLiving already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
@@ -76,7 +77,7 @@ DEALLOCATE PREPARE stmt;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
-        'SELECT "otherPlaceOfCurrentLiving already exists in i_beneficiarydetails_rmnch";')
+        'SELECT ''otherPlaceOfCurrentLiving already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
@@ -90,11 +91,122 @@ DEALLOCATE PREPARE stmt;
 SET @sql = (
     SELECT IF(COUNT(*) = 0,
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN institutionName VARCHAR(255) NULL;',
-        'SELECT "institutionName already exists in i_beneficiarydetails_rmnch";')
+        'SELECT ''institutionName already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
     WHERE TABLE_SCHEMA = 'db_identity'
       AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
       AND COLUMN_NAME = 'institutionName'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================================
+-- i_householddetails
+-- ==========================================================
+
+-- address
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_householddetails ADD COLUMN address VARCHAR(500) NULL;',
+        'SELECT ''address already exists in i_householddetails'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_householddetails'
+      AND COLUMN_NAME = 'address'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- totalHhMembers
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_householddetails ADD COLUMN totalHhMembers INT NULL;',
+        'SELECT ''totalHhMembers already exists in i_householddetails'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_householddetails'
+      AND COLUMN_NAME = 'totalHhMembers'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- registeredAtCampSite
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_householddetails ADD COLUMN registeredAtCampSite VARCHAR(255) NULL;',
+        'SELECT ''registeredAtCampSite already exists in i_householddetails'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_householddetails'
+      AND COLUMN_NAME = 'registeredAtCampSite'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- registeredAtCampSiteId
+SET @sql = (
+    SELECT IF(COUNT(*) = 0,
+        'ALTER TABLE db_identity.i_householddetails ADD COLUMN registeredAtCampSiteId INT NULL;',
+        'SELECT ''registeredAtCampSiteId already exists in i_householddetails'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_householddetails'
+      AND COLUMN_NAME = 'registeredAtCampSiteId'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================================
+-- Modify isGpsUnavailable in i_beneficiarydetails_rmnch
+-- ==========================================================
+
+SET @sql = (
+    SELECT IF(COUNT(*) = 1,
+        'ALTER TABLE db_identity.i_beneficiarydetails_rmnch MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
+        'SELECT ''isGpsUnavailable does not exist in i_beneficiarydetails_rmnch'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+      AND COLUMN_NAME = 'isGpsUnavailable'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================================
+-- Modify isGpsUnavailable in i_householddetails
+-- ==========================================================
+
+SET @sql = (
+    SELECT IF(COUNT(*) = 1,
+        'ALTER TABLE db_identity.i_householddetails MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
+        'SELECT ''isGpsUnavailable does not exist in i_householddetails'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_householddetails'
+      AND COLUMN_NAME = 'isGpsUnavailable'
+);
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- ==========================================================
+-- Modify isGpsUnavailable in i_beneficiaryaddress
+-- ==========================================================
+
+SET @sql = (
+    SELECT IF(COUNT(*) = 1,
+        'ALTER TABLE db_identity.i_beneficiaryaddress MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
+        'SELECT ''isGpsUnavailable does not exist in i_beneficiaryaddress'';')
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = 'db_identity'
+      AND TABLE_NAME = 'i_beneficiaryaddress'
+      AND COLUMN_NAME = 'isGpsUnavailable'
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;

--- a/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
+++ b/src/main/resources/db/migration/dbidentity/V19_Non_Household_Add_Column.sql
@@ -9,6 +9,13 @@
 
 USE db_identity;
 
+SET @schema_name = 'db_identity';
+SET @tbl_beneficiarydetails = 'i_beneficiarydetails';
+SET @tbl_beneficiarydetails_rmnch = 'i_beneficiarydetails_rmnch';
+SET @tbl_householddetails = 'i_householddetails';
+SET @tbl_beneficiaryaddress = 'i_beneficiaryaddress';
+SET @col_gps_unavailable = 'isGpsUnavailable';
+
 -- ==========================================================
 -- i_beneficiarydetails
 -- ==========================================================
@@ -19,8 +26,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
         'SELECT ''placeOfCurrentLiving already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails
       AND COLUMN_NAME = 'placeOfCurrentLiving'
 );
 PREPARE stmt FROM @sql;
@@ -33,8 +40,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
         'SELECT ''otherPlaceOfCurrentLiving already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails
       AND COLUMN_NAME = 'otherPlaceOfCurrentLiving'
 );
 PREPARE stmt FROM @sql;
@@ -47,8 +54,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails ADD COLUMN institutionName VARCHAR(255) NULL;',
         'SELECT ''institutionName already exists in i_beneficiarydetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails
       AND COLUMN_NAME = 'institutionName'
 );
 PREPARE stmt FROM @sql;
@@ -65,8 +72,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN placeOfCurrentLiving VARCHAR(255) NULL;',
         'SELECT ''placeOfCurrentLiving already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails_rmnch
       AND COLUMN_NAME = 'placeOfCurrentLiving'
 );
 PREPARE stmt FROM @sql;
@@ -79,8 +86,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN otherPlaceOfCurrentLiving VARCHAR(255) NULL;',
         'SELECT ''otherPlaceOfCurrentLiving already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails_rmnch
       AND COLUMN_NAME = 'otherPlaceOfCurrentLiving'
 );
 PREPARE stmt FROM @sql;
@@ -93,8 +100,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch ADD COLUMN institutionName VARCHAR(255) NULL;',
         'SELECT ''institutionName already exists in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails_rmnch
       AND COLUMN_NAME = 'institutionName'
 );
 PREPARE stmt FROM @sql;
@@ -111,8 +118,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_householddetails ADD COLUMN address VARCHAR(500) NULL;',
         'SELECT ''address already exists in i_householddetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_householddetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_householddetails
       AND COLUMN_NAME = 'address'
 );
 PREPARE stmt FROM @sql;
@@ -125,8 +132,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_householddetails ADD COLUMN totalHhMembers INT NULL;',
         'SELECT ''totalHhMembers already exists in i_householddetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_householddetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_householddetails
       AND COLUMN_NAME = 'totalHhMembers'
 );
 PREPARE stmt FROM @sql;
@@ -139,8 +146,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_householddetails ADD COLUMN registeredAtCampSite VARCHAR(255) NULL;',
         'SELECT ''registeredAtCampSite already exists in i_householddetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_householddetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_householddetails
       AND COLUMN_NAME = 'registeredAtCampSite'
 );
 PREPARE stmt FROM @sql;
@@ -153,8 +160,8 @@ SET @sql = (
         'ALTER TABLE db_identity.i_householddetails ADD COLUMN registeredAtCampSiteId INT NULL;',
         'SELECT ''registeredAtCampSiteId already exists in i_householddetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_householddetails'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_householddetails
       AND COLUMN_NAME = 'registeredAtCampSiteId'
 );
 PREPARE stmt FROM @sql;
@@ -170,9 +177,9 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiarydetails_rmnch MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
         'SELECT ''isGpsUnavailable does not exist in i_beneficiarydetails_rmnch'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiarydetails_rmnch'
-      AND COLUMN_NAME = 'isGpsUnavailable'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiarydetails_rmnch
+      AND COLUMN_NAME = @col_gps_unavailable
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
@@ -187,9 +194,9 @@ SET @sql = (
         'ALTER TABLE db_identity.i_householddetails MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
         'SELECT ''isGpsUnavailable does not exist in i_householddetails'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_householddetails'
-      AND COLUMN_NAME = 'isGpsUnavailable'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_householddetails
+      AND COLUMN_NAME = @col_gps_unavailable
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;
@@ -204,9 +211,9 @@ SET @sql = (
         'ALTER TABLE db_identity.i_beneficiaryaddress MODIFY COLUMN isGpsUnavailable TINYINT(1) NULL DEFAULT 0;',
         'SELECT ''isGpsUnavailable does not exist in i_beneficiaryaddress'';')
     FROM INFORMATION_SCHEMA.COLUMNS
-    WHERE TABLE_SCHEMA = 'db_identity'
-      AND TABLE_NAME = 'i_beneficiaryaddress'
-      AND COLUMN_NAME = 'isGpsUnavailable'
+    WHERE TABLE_SCHEMA = @schema_name
+      AND TABLE_NAME = @tbl_beneficiaryaddress
+      AND COLUMN_NAME = @col_gps_unavailable
 );
 PREPARE stmt FROM @sql;
 EXECUTE stmt;

--- a/src/main/resources/db/migration/dbiemr/V96_Device_Integration.sql
+++ b/src/main/resources/db/migration/dbiemr/V96_Device_Integration.sql
@@ -1,0 +1,128 @@
+-- ==========================================================
+-- Diagnostic device integration schema for db_iemr
+-- Run against your local MySQL:
+-- mysql -u root -p db_iemr < diagnostic_order_schema.sql
+--
+-- Purpose:
+-- Creates all database tables required for diagnostic device
+-- integration.
+--
+-- Safe to execute multiple times because CREATE TABLE IF NOT
+-- EXISTS will skip table creation if the table already exists.
+--
+-- Note:
+-- This script only creates new tables. It does NOT modify an
+-- existing table if its schema differs. Future schema changes
+-- should be handled through separate ALTER TABLE migration scripts.
+-- ==========================================================
+
+USE db_iemr;
+
+-- ==========================================================
+-- Stores diagnostic order details sent to external providers.
+-- One record represents one diagnostic order.
+-- ==========================================================
+CREATE TABLE IF NOT EXISTS tb_diagnostic_order (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    order_event VARCHAR(100) NULL,
+    ben_reg_id BIGINT NULL,
+    provider_service_name VARCHAR(50) NULL,
+    provider_code VARCHAR(50) NULL,
+    order_type VARCHAR(20) NULL,
+    external_order_id VARCHAR(100) NULL,
+    provider_order_id VARCHAR(100) NULL,
+    status VARCHAR(20) NULL,
+    retry_count INT NULL DEFAULT 0,
+    last_polled_at DATETIME NULL,
+    test_completed_at DATETIME NULL,
+    error_message TEXT NULL,
+    reason_for_refusal TEXT NULL,
+    push_response_json LONGTEXT NULL,
+    patient_first_name VARCHAR(100) NULL,
+    patient_last_name VARCHAR(100) NULL,
+    patient_date_of_birth VARCHAR(10) NULL,
+    patient_sex VARCHAR(10) NULL,
+    created_by VARCHAR(100) NULL,
+    created_date DATETIME NOT NULL,
+    modified_by VARCHAR(100) NULL,
+    last_mod_date DATETIME NULL,
+    deleted BIT NOT NULL DEFAULT 0,
+    vanID INT NULL,
+    parkingPlaceID INT NULL,
+    visitCode BIGINT NULL,
+    processed VARCHAR(1) NOT NULL DEFAULT 'N',
+    vanSerialNo BIGINT NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_diagnostic_order_ben_visit_type (ben_reg_id, visitCode, order_type),
+    UNIQUE KEY uk_diagnostic_order_external_order_id (external_order_id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ==========================================================
+-- Stores diagnostic results received for an order.
+-- Each diagnostic order can have one result.
+-- ==========================================================
+CREATE TABLE IF NOT EXISTS tb_diagnostic_result (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    diagnostic_order_id BIGINT NOT NULL,
+    ben_reg_id BIGINT NULL,
+    provider_status VARCHAR(20) NULL,
+    result_summary TEXT NULL,
+    raw_response_json LONGTEXT NULL,
+    tb_presence BIT NULL,
+    tb_confidence DOUBLE NULL,
+    drug_resistance_presence BIT NULL,
+    created_by VARCHAR(100) NULL,
+    created_date DATETIME NOT NULL,
+    modified_by VARCHAR(100) NULL,
+    last_mod_date DATETIME NULL,
+    deleted BIT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_diagnostic_result_order_id (diagnostic_order_id),
+    CONSTRAINT fk_diagnostic_result_order FOREIGN KEY (diagnostic_order_id) REFERENCES tb_diagnostic_order (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ==========================================================
+-- Stores documents/assets associated with diagnostic results
+-- such as reports, PDFs, images, etc.
+-- ==========================================================
+CREATE TABLE IF NOT EXISTS tb_diagnostic_document (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    diagnostic_order_id BIGINT NULL,
+    ben_reg_id BIGINT NULL,
+    order_type VARCHAR(20) NULL,
+    asset_type VARCHAR(50) NULL,
+    document_type VARCHAR(30) NULL,
+    epoch_time BIGINT NULL,
+    stored_file_name VARCHAR(150) NULL,
+    stored_path VARCHAR(255) NULL,
+    sha256_hash VARCHAR(64) NULL,
+    content_type VARCHAR(100) NULL,
+    original_file_name VARCHAR(255) NULL,
+    created_by VARCHAR(100) NULL,
+    created_date DATETIME NOT NULL,
+    modified_by VARCHAR(100) NULL,
+    last_mod_date DATETIME NULL,
+    deleted BIT NOT NULL DEFAULT 0,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_diagnostic_document_order_doctype (diagnostic_order_id, document_type),
+    KEY idx_diagnostic_document_ben_reg_id (ben_reg_id),
+    KEY idx_diagnostic_document_order_type (order_type),
+    KEY idx_diagnostic_document_epoch_time (epoch_time),
+    CONSTRAINT fk_diagnostic_document_order FOREIGN KEY (diagnostic_order_id) REFERENCES tb_diagnostic_order (id)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ==========================================================
+-- Stores authentication tokens used for communicating with
+-- external diagnostic providers.
+-- ==========================================================
+CREATE TABLE IF NOT EXISTS tb_diagnostic_provider_token (
+    id BIGINT NOT NULL AUTO_INCREMENT,
+    provider_code VARCHAR(50) NOT NULL,
+    token_type VARCHAR(20) NOT NULL,
+    token_value TEXT NOT NULL,
+    expires_at DATETIME NULL,
+    created_date DATETIME NOT NULL,
+    last_mod_date DATETIME NULL,
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_diagnostic_provider_token_code_type (provider_code, token_type)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/src/main/resources/db/migration/dbiemr/V96_Device_Integration.sql
+++ b/src/main/resources/db/migration/dbiemr/V96_Device_Integration.sql
@@ -47,11 +47,17 @@ CREATE TABLE IF NOT EXISTS tb_diagnostic_order (
     modified_by VARCHAR(100) NULL,
     last_mod_date DATETIME NULL,
     deleted BIT NOT NULL DEFAULT 0,
+
+    -- Sync/Common Fields
     vanID INT NULL,
     parkingPlaceID INT NULL,
     visitCode BIGINT NULL,
     processed VARCHAR(1) NOT NULL DEFAULT 'N',
     vanSerialNo BIGINT NULL,
+    SyncedDate DATETIME NULL,
+    Syncedby VARCHAR(50) NULL,
+    SyncFailureReason TEXT NULL,
+
     PRIMARY KEY (id),
     UNIQUE KEY uk_diagnostic_order_ben_visit_type (ben_reg_id, visitCode, order_type),
     UNIQUE KEY uk_diagnostic_order_external_order_id (external_order_id)
@@ -76,9 +82,21 @@ CREATE TABLE IF NOT EXISTS tb_diagnostic_result (
     modified_by VARCHAR(100) NULL,
     last_mod_date DATETIME NULL,
     deleted BIT NOT NULL DEFAULT 0,
+
+    -- Sync/Common Fields
+    vanID INT NULL,
+    parkingPlaceID INT NULL,
+    processed VARCHAR(1) NOT NULL DEFAULT 'N',
+    vanSerialNo BIGINT NULL,
+    SyncedDate DATETIME NULL,
+    Syncedby VARCHAR(50) NULL,
+    SyncFailureReason TEXT NULL,
+
     PRIMARY KEY (id),
     UNIQUE KEY uk_diagnostic_result_order_id (diagnostic_order_id),
-    CONSTRAINT fk_diagnostic_result_order FOREIGN KEY (diagnostic_order_id) REFERENCES tb_diagnostic_order (id)
+    CONSTRAINT fk_diagnostic_result_order
+    FOREIGN KEY (diagnostic_order_id)
+    REFERENCES tb_diagnostic_order (id)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ==========================================================
@@ -103,12 +121,24 @@ CREATE TABLE IF NOT EXISTS tb_diagnostic_document (
     modified_by VARCHAR(100) NULL,
     last_mod_date DATETIME NULL,
     deleted BIT NOT NULL DEFAULT 0,
+
+    -- Sync/Common Fields
+    vanID INT NULL,
+    parkingPlaceID INT NULL,
+    processed VARCHAR(1) NOT NULL DEFAULT 'N',
+    vanSerialNo BIGINT NULL,
+    SyncedDate DATETIME NULL,
+    Syncedby VARCHAR(50) NULL,
+    SyncFailureReason TEXT NULL,
+
     PRIMARY KEY (id),
     UNIQUE KEY uk_diagnostic_document_order_doctype (diagnostic_order_id, document_type),
     KEY idx_diagnostic_document_ben_reg_id (ben_reg_id),
     KEY idx_diagnostic_document_order_type (order_type),
     KEY idx_diagnostic_document_epoch_time (epoch_time),
-    CONSTRAINT fk_diagnostic_document_order FOREIGN KEY (diagnostic_order_id) REFERENCES tb_diagnostic_order (id)
+    CONSTRAINT fk_diagnostic_document_order
+    FOREIGN KEY (diagnostic_order_id)
+    REFERENCES tb_diagnostic_order (id)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- ==========================================================
@@ -123,6 +153,16 @@ CREATE TABLE IF NOT EXISTS tb_diagnostic_provider_token (
     expires_at DATETIME NULL,
     created_date DATETIME NOT NULL,
     last_mod_date DATETIME NULL,
+
+    -- Sync/Common Fields
+    vanID INT NULL,
+    parkingPlaceID INT NULL,
+    processed VARCHAR(1) NOT NULL DEFAULT 'N',
+    vanSerialNo BIGINT NULL,
+    SyncedDate DATETIME NULL,
+    Syncedby VARCHAR(50) NULL,
+    SyncFailureReason TEXT NULL,
+
     PRIMARY KEY (id),
     UNIQUE KEY uk_diagnostic_provider_token_code_type (provider_code, token_type)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Add two new Flyway migrations:                                                                                                                                                                                           
                                                                                                                                                                                                                           
  - db_identity V19: Adds placeOfCurrentLiving, otherPlaceOfCurrentLiving,                                                                                                                                                 
    and institutionName columns to i_beneficiarydetails and                                                                                                                                                                
    i_beneficiarydetails_rmnch to capture a beneficiary's current place                                                                                                                                                    
    of residence. Idempotent — checks INFORMATION_SCHEMA before altering                                                                                                                                                   
    so it is safe to re-run.                                                                                                                                                                                               
                                                                                                                                                                                                                           
  - db_iemr V96: Creates the schema for diagnostic device integration —                                                                                                                                                    
    tb_diagnostic_order (orders sent to external diagnostic providers),                                                                                                                                                    
    tb_diagnostic_result (results per order), tb_diagnostic_document                                                                                                                                                       
    (reports/files linked to a result), and                                                                                                                                                                                
    tb_diagnostic_provider_token (auth tokens for provider APIs). Uses                                                                                                                                                     
    CREATE TABLE IF NOT EXISTS, so re-running is safe; future schema                                                                                                                                                       
    changes should ship as separate ALTER migrations. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database support for additional place-of-current-living fields (including alternative and institution name) and expanded household address/registration details.
  * Introduced diagnostic device integration tables for diagnostic orders, results, related documents, and provider tokens (with soft-delete and uniqueness constraints).

* **Bug Fixes**
  * Improved migration safety with fully idempotent, re-runnable schema updates.
  * Ensured `isGpsUnavailable` is normalized consistently across affected tables when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->